### PR TITLE
Translate to Portuguese (Brazil): changemode.po and slimbookbattery.po

### DIFF
--- a/translation_directory/locale/pt_BR/slimbookbattery-changemode.po
+++ b/translation_directory/locale/pt_BR/slimbookbattery-changemode.po
@@ -11,81 +11,81 @@ msgstr ""
 "POT-Creation-Date: 2019-05-09 14:08+0200\n"
 "PO-Revision-Date: 2019-05-09 17:59+0200\n"
 "Last-Translator: SLIMBOOK <dev@slimbook.es>\n"
-"Language-Team: English <LL@li.org>\n"
-"Language: English\n"
+"Language-Team: Portuguese (Brazil)<LL@li.org>\n"
+"Language: Portuguese (Brazil)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: slimbookbattery-changemode.py:31
 msgid "Has an nvidia graphics card"
-msgstr ""
+msgstr "Tem uma placa gráfica nvidia"
 
 #: slimbookbattery-changemode.py:36
 msgid "Changes to nvidia graphics: power off mode"
-msgstr ""
+msgstr "Alterações para nvidia graphics: modo de desligamento"
 
 #: slimbookbattery-changemode.py:41
 msgid "Changes to intel graphics: energy saving"
-msgstr ""
+msgstr "Alterações para intel graphics: economia de energia"
 
 #: slimbookbattery-changemode.py:44
 msgid "Alredy using intel graphics: energy saving"
-msgstr ""
+msgstr "Já usando intel graphics: economia de energia"
 
 #: slimbookbattery-changemode.py:48
 msgid "Changes to nvidia graphics: energy saving"
-msgstr ""
+msgstr "Alterações para nvidia graphics: economia de energia"
 
 #: slimbookbattery-changemode.py:51
 msgid "Alredy using nvidia graphics: energy saving"
-msgstr ""
+msgstr "Já usando nvidia graphics: economia de energia"
 
 #: slimbookbattery-changemode.py:55
 msgid "Changes to intel graphics: balanced"
-msgstr ""
+msgstr "Alterações para intel graphics: equilibrado"
 
 #: slimbookbattery-changemode.py:58
 msgid "Alredy using intel graphics: balanced"
-msgstr ""
+msgstr "Já usando intel graphics: equilibrado"
 
 #: slimbookbattery-changemode.py:62
 msgid "Changes to nvidia graphics: balanced"
-msgstr ""
+msgstr "Alterações para nvidia graphics: equilibrado"
 
 #: slimbookbattery-changemode.py:65
 msgid "Alredy using nvidia graphics: balanced"
-msgstr ""
+msgstr "Já usando nvidia graphics: equilibrado"
 
 #: slimbookbattery-changemode.py:70
 msgid "Changes to nvidia graphics: maximumum performance"
-msgstr ""
+msgstr "Alterações para nvidia graphics: máximo desempenho"
 
 #: slimbookbattery-changemode.py:73
 msgid "Alredy using nvidia graphics: maximum performance"
-msgstr ""
+msgstr "Já usando nvidia graphics: máxim desempenho"
 
 #: slimbookbattery-changemode.py:77
 msgid ""
 "Modifications for AMD and Intel graphics are going to be made: energy saving"
 msgstr ""
-
+"Modificações para AMD e Intel graphics vão ser feitas: economia de energia"
 #: slimbookbattery-changemode.py:131
 msgid "AMD and Intel graphics back to default configuration: energy saving"
-msgstr ""
+msgstr "AMD e Intel graphics voltaram para a configuração padrão: economia de energia"
 
 #: slimbookbattery-changemode.py:136
 msgid "Modifications for AMD and Intel graphics are going to be made: balanced"
-msgstr ""
+msgstr "Modificações para AMD e Intel graphics vão ser feitas: equilibrado"
 
 #: slimbookbattery-changemode.py:184
 msgid "AMD and Intel graphics back to default configuration: balanced"
-msgstr ""
+msgstr "AMD e Intel graphics voltaram para a configuração padrão: equilibrado"
 
 #: slimbookbattery-changemode.py:207
 msgid "Brightness value converted: "
-msgstr ""
+msgstr "Intensidade de brilho convertido: "
 
 #: slimbookbattery-changemode.py:213
 msgid "Error calling accion param"
-msgstr ""
+msgstr "Erro chamando parâmetro accion"

--- a/translation_directory/locale/pt_BR/slimbookbattery.po
+++ b/translation_directory/locale/pt_BR/slimbookbattery.po
@@ -11,8 +11,8 @@ msgstr ""
 "POT-Creation-Date: 2019-05-09 14:08+0200\n"
 "PO-Revision-Date: 2019-05-09 17:59+0200\n"
 "Last-Translator: SLIMBOOK <dev@slimbook.es>\n"
-"Language-Team: English <LL@li.org>\n"
-"Language: English\n"
+"Language-Team: Portuguese (Brazil) <LL@li.org>\n"
+"Language: Portuguese (Brazil)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -43,119 +43,119 @@ msgstr ""
 
 #: slimbookbattery.py:70
 msgid "File config it's correct"
-msgstr ""
+msgstr "Arquivo de configuração está correto"
 
 #: slimbookbattery.py:102
 msgid "The user introduces password correctly"
-msgstr ""
+msgstr "O usuário digitou a senha corretamente"
 
 #: slimbookbattery.py:104 slimbookbattery.py:415 slimbookbattery.py:444
 #: slimbookbattery.py:470 slimbookbattery.py:495 slimbookbattery.py:596
 msgid "Wrong password"
-msgstr ""
+msgstr "Senha errada"
 
 #: slimbookbattery.py:158
 msgid "Cycle alerts enabled and applicacion it's on"
-msgstr ""
+msgstr "Alertas de ciclos ativados e aplicativo rodando"
 
 #: slimbookbattery.py:170
 msgid "Cycle alerts disabled and application it's on"
-msgstr ""
+msgstr "Alertas de ciclos desativados e aplicativo rodando"
 
 #: slimbookbattery.py:179
 msgid "Cycle alerts are enabled and the application it's off"
-msgstr ""
+msgstr "Alertas de ciclo estão ativados e aplicativo está encerrado"
 
 #: slimbookbattery.py:182
 msgid "Cycle alerts are disabled and the application it's off"
-msgstr ""
+msgstr "Alertas de ciclo estão desativados e aplicativo está encerrado"
 
 #: slimbookbattery.py:217
 msgid "Energy Saving"
-msgstr ""
+msgstr "Economia de energia"
 
 #: slimbookbattery.py:222
 msgid "Balanced"
-msgstr ""
+msgstr "Equilibrado"
 
 #: slimbookbattery.py:227
 msgid "Maximum Performance"
-msgstr ""
+msgstr "Máximo Desempenho"
 
 #: slimbookbattery.py:232
 msgid "Off"
-msgstr ""
+msgstr "Desligado"
 
 #: slimbookbattery.py:237
 msgid "Advanced mode"
-msgstr ""
+msgstr "Modo avançado"
 
 #: slimbookbattery.py:240
 msgid "Exit"
-msgstr ""
+msgstr "Sair"
 
 #: slimbookbattery.py:323
 msgid "Max battery: "
-msgstr ""
+msgstr "Bateria max."
 
 #: slimbookbattery.py:324
 msgid "Min battery: "
-msgstr ""
+msgstr "Bateria min."
 
 #: slimbookbattery.py:325
 msgid "Max times: "
-msgstr ""
+msgstr "Máx. número de vezes"
 
 #: slimbookbattery.py:326
 msgid "Time between warnings: "
-msgstr ""
+msgstr "Tempo entre avisos"
 
 #: slimbookbattery.py:338
 msgid "Current battery: "
-msgstr ""
+msgstr "Bateria atual:"
 
 #: slimbookbattery.py:344
 msgid "Alerts disabled"
-msgstr ""
+msgstr "Alertas desativados"
 
 #: slimbookbattery.py:346
 msgid "Alerts variable error"
-msgstr ""
+msgstr "Erro de variável de alertas"
 
 #: slimbookbattery.py:351
 msgid "High battery level (Remaining "
-msgstr ""
+msgstr "Alto nível de bateria (Restante"
 
 #: slimbookbattery.py:351 slimbookbattery.py:359
 msgid " Warning "
-msgstr ""
+msgstr " Aviso"
 
 #: slimbookbattery.py:351 slimbookbattery.py:359
 msgid " Time until the next warning "
-msgstr ""
+msgstr " Tempo até o próximo aviso"
 
 #: slimbookbattery.py:351 slimbookbattery.py:359
 msgid " seconds"
-msgstr ""
+msgstr " segundos"
 
 #: slimbookbattery.py:354
 msgid "High battery. Disconnect your power supply."
-msgstr ""
+msgstr "Bateria cheia. Desconecte seu cabo de energia."
 
 #: slimbookbattery.py:359
 msgid "Critical battery level (Remaining "
-msgstr ""
+msgstr "Nível crítico de bateria (Restante "
 
 #: slimbookbattery.py:362
 msgid "Low battery. Connect your power supply."
-msgstr ""
+msgstr "Pouca bateria. Conecte seu cabo de energia."
 
 #: slimbookbattery.py:407 slimbookbattery.py:421 slimbookbattery.py:435
 #: slimbookbattery.py:461 slimbookbattery.py:520 slimbookbattery.py:527
 #: slimbookbattery.py:539 slimbookbattery.py:556 slimbookbattery.py:563
 #: slimbookbattery.py:590
 msgid "not process"
-msgstr ""
+msgstr "não processar"
 
 #: slimbookbattery.py:414
 msgid ""
@@ -164,7 +164,7 @@ msgstr "Wrong password"
 
 #: slimbookbattery.py:656
 msgid "Alert!"
-msgstr ""
+msgstr "Alerta!"
 
 #: slimbookbattery.py:658
 msgid ""
@@ -172,7 +172,10 @@ msgid ""
 "of them may take effect. \n"
 "Do you want to restart?"
 msgstr ""
+"As alterações foram aplicadas, mas há a necessidade de reiniciar o sistema"
+"para que algumas delas tenham efeito total."
+"Você quer reiniciar?"
 
 #: slimbookbattery.py:663
 msgid "System will not restart"
-msgstr ""
+msgstr "O sistema não vai reiniciar"


### PR DESCRIPTION
Finishing translating the other 2 files, despite I think one of those did not need to be translated.

Translation problem identified at:

> #: slimbookbattery.py:414
> msgid ""
> "No se cierra la aplicación, ya que el usuario no ha introducido la contraseña"
> msgstr "Wrong password"
> 